### PR TITLE
:recycle: 支払いデータの税金の有無カラムを削除した

### DIFF
--- a/backend/database/migrations/20210801162008_create_init.up.sql
+++ b/backend/database/migrations/20210801162008_create_init.up.sql
@@ -1,7 +1,6 @@
 CREATE TABLE payments (
     pk                INT UNSIGNED NOT NULL AUTO_INCREMENT,
     id                VARCHAR(256) NOT NULL,
-    tax_included      BOOLEAN      NOT NULL,
     paid_on           DATETIME     NOT NULL,
     number_of_product INT UNSIGNED NOT NULL,
     amount            INT UNSIGNED NOT NULL,


### PR DESCRIPTION
理由

税金があるかないかではなく、税率がどれだけあったかの方が意味のあるデータ
ただ、税率は変わるし、後から変更したいとかはないので削除する

amount には税率を計算した結果を格納するようにする